### PR TITLE
Fix background opacity

### DIFF
--- a/src/setting_tab/SettingTab.ts
+++ b/src/setting_tab/SettingTab.ts
@@ -20,7 +20,8 @@ import {
 	ComponentTagsEnableMultipleTags,
 	ComponentTagsEnableSeparateBackground,
 	ComponentKanbanHideHashtags,
-	ComponentTagsEnableSeparateLuminance
+	ComponentTagsEnableSeparateLuminance,
+	ComponentTagsEnableDarkLightDifference
 } from "src/setting_tab/components";
 // ---------------------------------------------------------------------------------------------------------------------
 // Code
@@ -42,26 +43,28 @@ export class SettingTab extends PluginSettingTab {
 		comp_debug:								SettingsTabComponent,
 		comp_debug_reloadcss:					SettingsTabComponent,
 		comp_tags_enable_luminance:			    SettingsTabComponent,
+		comp_tags_enable_dark_light_difference: SettingsTabComponent,
 	}
 
 	constructor(plugin: ColoredTagWranglerPlugin) {
 		super(plugin.app, plugin);
 		this.plugin = plugin;
 		this._components = {
-			comp_tags: 							new ComponentTags(plugin, this),
-			comp_tags_canvas:					new ComponentTagsCanvas(plugin, this),
-			comp_tags_enable_multiple_tags:		new ComponentTagsEnableMultipleTags(plugin, this),
-			comp_tags_enable_background: 		new ComponentTagsEnableSeparateBackground(plugin, this),
-			comp_folder_note:					new ComponentFolderNote(plugin, this),
-			comp_folder_note_auto_detect:		new ComponentFolderNoteAutoDetect(plugin, this),
-			comp_folder_note_folder_tag_links:	new ComponentFolderNoteFolderTagLinks(plugin, this),
-			comp_kanban: 						new ComponentKanban(plugin,this),
-			comp_kanban_cards:					new ComponentKanbanCards(plugin,this),
-			comp_kanban_lists:					new ComponentKanbanLists(plugin,this),
-			comp_kanban_hashtags:				new ComponentKanbanHideHashtags(plugin,this),
-			comp_debug:							new ComponentDebug(plugin,this),
-			comp_debug_reloadcss:				new ComponentDebugReloadCSS(plugin,this),
-			comp_tags_enable_luminance:			new ComponentTagsEnableSeparateLuminance(plugin, this),
+			comp_tags: 								new ComponentTags(plugin, this),
+			comp_tags_canvas:						new ComponentTagsCanvas(plugin, this),
+			comp_tags_enable_multiple_tags:			new ComponentTagsEnableMultipleTags(plugin, this),
+			comp_tags_enable_background: 			new ComponentTagsEnableSeparateBackground(plugin, this),
+			comp_folder_note:						new ComponentFolderNote(plugin, this),
+			comp_folder_note_auto_detect:			new ComponentFolderNoteAutoDetect(plugin, this),
+			comp_folder_note_folder_tag_links:		new ComponentFolderNoteFolderTagLinks(plugin, this),
+			comp_kanban: 							new ComponentKanban(plugin,this),
+			comp_kanban_cards:						new ComponentKanbanCards(plugin,this),
+			comp_kanban_lists:						new ComponentKanbanLists(plugin,this),
+			comp_kanban_hashtags:					new ComponentKanbanHideHashtags(plugin,this),
+			comp_debug:								new ComponentDebug(plugin,this),
+			comp_debug_reloadcss:					new ComponentDebugReloadCSS(plugin,this),
+			comp_tags_enable_luminance:				new ComponentTagsEnableSeparateLuminance(plugin, this),
+			comp_tags_enable_dark_light_difference: new ComponentTagsEnableDarkLightDifference(plugin,this),
 
 		}
 	}
@@ -86,6 +89,7 @@ export class SettingTab extends PluginSettingTab {
 		this._components.comp_tags_enable_multiple_tags.create_component(containerEl);
 		this._components.comp_tags_enable_background.create_component(containerEl);
 		this._components.comp_tags_enable_luminance.create_component(containerEl);
+		this._components.comp_tags_enable_dark_light_difference.create_component(containerEl);
 
 		// Kanban Settings
 		// -------------------------------------------------------------------------------------------------------------

--- a/src/setting_tab/SettingTab.ts
+++ b/src/setting_tab/SettingTab.ts
@@ -21,7 +21,8 @@ import {
 	ComponentTagsEnableSeparateBackground,
 	ComponentKanbanHideHashtags,
 	ComponentTagsEnableSeparateLuminance,
-	ComponentTagsEnableDarkLightDifference
+	ComponentTagsEnableDarkLightDifference,
+	ComponentTagsEnableBackgroundOpacity
 } from "src/setting_tab/components";
 // ---------------------------------------------------------------------------------------------------------------------
 // Code
@@ -44,6 +45,7 @@ export class SettingTab extends PluginSettingTab {
 		comp_debug_reloadcss:					SettingsTabComponent,
 		comp_tags_enable_luminance:			    SettingsTabComponent,
 		comp_tags_enable_dark_light_difference: SettingsTabComponent,
+		comp_tags_enable_background_opacity: SettingsTabComponent,
 	}
 
 	constructor(plugin: ColoredTagWranglerPlugin) {
@@ -65,6 +67,7 @@ export class SettingTab extends PluginSettingTab {
 			comp_debug_reloadcss:					new ComponentDebugReloadCSS(plugin,this),
 			comp_tags_enable_luminance:				new ComponentTagsEnableSeparateLuminance(plugin, this),
 			comp_tags_enable_dark_light_difference: new ComponentTagsEnableDarkLightDifference(plugin,this),
+			comp_tags_enable_background_opacity: 	new ComponentTagsEnableBackgroundOpacity(plugin,this),
 
 		}
 	}
@@ -78,7 +81,7 @@ export class SettingTab extends PluginSettingTab {
 		// -------------------------------------------------------------------------------------------------------------
 		containerEl.createEl('h2', {text: "Obsidian tags"});
 		containerEl.createDiv({cls:"setting-item-description",text: `Don't add the '#' before the tag. Write everything in lowercase without spaces.`});
-		containerEl.createDiv({cls:"setting-item-description",text: `If you forget this, this done for you in code, resulting in the input being changed if you reload this page.`});
+		containerEl.createDiv({cls:"setting-item-description",text: `If you forget this, this is done in code for you, resulting in the input being changed.`});
 		containerEl.createEl('br');
 
 		// Tags lists and which component they should adhere to
@@ -90,6 +93,7 @@ export class SettingTab extends PluginSettingTab {
 		this._components.comp_tags_enable_background.create_component(containerEl);
 		this._components.comp_tags_enable_luminance.create_component(containerEl);
 		this._components.comp_tags_enable_dark_light_difference.create_component(containerEl);
+		this._components.comp_tags_enable_background_opacity.create_component(containerEl);
 
 		// Kanban Settings
 		// -------------------------------------------------------------------------------------------------------------

--- a/src/setting_tab/SettingTab.ts
+++ b/src/setting_tab/SettingTab.ts
@@ -18,7 +18,9 @@ import {
 	ComponentFolderNoteAutoDetect,
 	ComponentFolderNoteFolderTagLinks,
 	ComponentTagsEnableMultipleTags,
-	ComponentTagsEnableSeparateBackground, ComponentKanbanHideHashtags
+	ComponentTagsEnableSeparateBackground,
+	ComponentKanbanHideHashtags,
+	ComponentTagsEnableSeparateLuminance
 } from "src/setting_tab/components";
 // ---------------------------------------------------------------------------------------------------------------------
 // Code
@@ -39,6 +41,7 @@ export class SettingTab extends PluginSettingTab {
 		comp_kanban_hashtags:					SettingsTabComponent,
 		comp_debug:								SettingsTabComponent,
 		comp_debug_reloadcss:					SettingsTabComponent,
+		comp_tags_enable_luminance:			    SettingsTabComponent,
 	}
 
 	constructor(plugin: ColoredTagWranglerPlugin) {
@@ -58,6 +61,8 @@ export class SettingTab extends PluginSettingTab {
 			comp_kanban_hashtags:				new ComponentKanbanHideHashtags(plugin,this),
 			comp_debug:							new ComponentDebug(plugin,this),
 			comp_debug_reloadcss:				new ComponentDebugReloadCSS(plugin,this),
+			comp_tags_enable_luminance:			new ComponentTagsEnableSeparateLuminance(plugin, this),
+
 		}
 	}
 	async display() {
@@ -80,6 +85,7 @@ export class SettingTab extends PluginSettingTab {
 		this._components.comp_tags_canvas.create_component(containerEl);
 		this._components.comp_tags_enable_multiple_tags.create_component(containerEl);
 		this._components.comp_tags_enable_background.create_component(containerEl);
+		this._components.comp_tags_enable_luminance.create_component(containerEl);
 
 		// Kanban Settings
 		// -------------------------------------------------------------------------------------------------------------

--- a/src/setting_tab/components/ComponentTags.ts
+++ b/src/setting_tab/components/ComponentTags.ts
@@ -114,7 +114,7 @@ export class ComponentTags extends SettingsTabComponent{
 						// Store the edited value to the background color, if we haven't enabled separate backgrounds
 						if (!this.plugin.settings.TagColors.EnableSeparateBackground){
 							let hsl = rgbToHsl(new_tag_content.color);
-							hsl.l = 2 * (hsl.l / 3);
+							hsl.l -= this.plugin.settings.TagColors.Values.LuminanceOffset;
 							new_tag_content.background_color = hslToRgb(hsl);
 						}
 						this.plugin.settings.TagColors.ColorPicker[tag_id] = new_tag_content;

--- a/src/setting_tab/components/ComponentTags.ts
+++ b/src/setting_tab/components/ComponentTags.ts
@@ -141,7 +141,7 @@ export class ComponentTags extends SettingsTabComponent{
 			setting
 				.addSlider(component => {
 						component
-							.setLimits(0, .5, 0.05)
+							.setLimits(-0.5, .5, 0.05)
 							.setValue(this.plugin.settings.TagColors.ColorPicker[tag_id].luminance_offset)
 							.onChange(async state => {
 								this.plugin.settings.TagColors.ColorPicker[tag_id].luminance_offset = state;

--- a/src/setting_tab/components/ComponentTagsEnableBackgroundOpacity.ts
+++ b/src/setting_tab/components/ComponentTagsEnableBackgroundOpacity.ts
@@ -1,0 +1,53 @@
+// ---------------------------------------------------------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------------------------------------------------------
+import {Setting} from "obsidian";
+import {SettingsTabComponent} from "src/setting_tab/SettingsTabComponent";
+// ---------------------------------------------------------------------------------------------------------------------
+// Code
+// ---------------------------------------------------------------------------------------------------------------------
+export class ComponentTagsEnableBackgroundOpacity extends SettingsTabComponent {
+	// -----------------------------------------------------------------------------------------------------------------
+	// methods
+	// -----------------------------------------------------------------------------------------------------------------
+	public create_component(containerEL:HTMLElement): Setting {
+		let setting = new Setting(containerEL)
+			.setName("Enable background opacity")
+			.setDesc(`
+				Makes the backgrounds of any tags, Canvas cards, etc... slightly opaque.
+				Recreates a pre 0.12.0 state.
+			`)
+			.addToggle(component => {
+					component
+						.setValue(this.plugin.settings.TagColors.EnableBackgroundOpacity)
+						.onChange(async state => {
+							this.plugin.settings.TagColors.EnableBackgroundOpacity = state;
+							await this.plugin.saveSettings();
+							await this.settings_tab.display();
+						})
+				}
+			)
+
+		if (this.plugin.settings.TagColors.EnableBackgroundOpacity){
+			setting.addText((text) => {
+				text
+					.setPlaceholder(this.plugin.settings.TagColors.Values.BackgroundOpacity.toString())
+					.setValue(this.plugin.settings.TagColors.Values.BackgroundOpacity.toString())
+					.onChange(async state => {
+						// Because this is a text component it needs to be cast to a number
+						let state_as_number = Number(state)
+						if (isNaN(state_as_number) || state_as_number === null){
+							state_as_number = 0
+						}
+
+						this.plugin.settings.TagColors.Values.BackgroundOpacity = state_as_number;
+						await this.plugin.saveSettings();
+					});
+			});
+		}
+		return setting
+	}
+}
+
+
+

--- a/src/setting_tab/components/ComponentTagsEnableDarkLightDifference.ts
+++ b/src/setting_tab/components/ComponentTagsEnableDarkLightDifference.ts
@@ -1,0 +1,30 @@
+// ---------------------------------------------------------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------------------------------------------------------
+import {Setting} from "obsidian";
+import {SettingsTabComponent} from "src/setting_tab/SettingsTabComponent";
+// ---------------------------------------------------------------------------------------------------------------------
+// Code
+// ---------------------------------------------------------------------------------------------------------------------
+export class ComponentTagsEnableDarkLightDifference extends SettingsTabComponent {
+	// -----------------------------------------------------------------------------------------------------------------
+	// methods
+	// -----------------------------------------------------------------------------------------------------------------
+	public create_component(containerEL:HTMLElement): Setting {
+		return new Setting(containerEL)
+			.setName("Enable different luminance formula for dark & light mode")
+			.setDesc("When enabled, applies the luminance offset differently depending on Dark or Light mode")
+			.addToggle(component => {
+					component
+						.setValue(this.plugin.settings.TagColors.EnableDarkLightDifference)
+						.onChange(async state => {
+							this.plugin.settings.TagColors.EnableDarkLightDifference = state;
+							await this.plugin.saveSettings();
+						})
+				}
+			)
+	}
+}
+
+
+

--- a/src/setting_tab/components/ComponentTagsEnableDarkLightDifference.ts
+++ b/src/setting_tab/components/ComponentTagsEnableDarkLightDifference.ts
@@ -13,7 +13,10 @@ export class ComponentTagsEnableDarkLightDifference extends SettingsTabComponent
 	public create_component(containerEL:HTMLElement): Setting {
 		return new Setting(containerEL)
 			.setName("Enable different luminance formula for dark & light mode")
-			.setDesc("When enabled, applies the luminance offset differently depending on Dark or Light mode.")
+			.setDesc(`
+				When enabled, applies the luminance offset differently depending on Dark or Light mode.
+				Formula stays the same in Dark mode, only applies to Light mode.
+			`)
 			.addToggle(component => {
 					component
 						.setValue(this.plugin.settings.TagColors.EnableDarkLightDifference)

--- a/src/setting_tab/components/ComponentTagsEnableDarkLightDifference.ts
+++ b/src/setting_tab/components/ComponentTagsEnableDarkLightDifference.ts
@@ -13,7 +13,7 @@ export class ComponentTagsEnableDarkLightDifference extends SettingsTabComponent
 	public create_component(containerEL:HTMLElement): Setting {
 		return new Setting(containerEL)
 			.setName("Enable different luminance formula for dark & light mode")
-			.setDesc("When enabled, applies the luminance offset differently depending on Dark or Light mode")
+			.setDesc("When enabled, applies the luminance offset differently depending on Dark or Light mode.")
 			.addToggle(component => {
 					component
 						.setValue(this.plugin.settings.TagColors.EnableDarkLightDifference)

--- a/src/setting_tab/components/ComponentTagsEnableMultipleTags.ts
+++ b/src/setting_tab/components/ComponentTagsEnableMultipleTags.ts
@@ -13,7 +13,7 @@ export class ComponentTagsEnableMultipleTags extends SettingsTabComponent {
 	public create_component(containerEL:HTMLElement): Setting {
 		return new Setting(containerEL)
 			.setName("Enable multiple tags per line")
-			.setDesc("Allows the usage of `;` to bind multiple tags to one color. (Currently only works with the Color picker)")
+			.setDesc("Allows the usage of `;` to bind multiple tags to one color. (Currently only works with the Color picker).")
 			.addToggle(component => {
 					component
 						.setValue(this.plugin.settings.TagColors.EnableMultipleTags)

--- a/src/setting_tab/components/ComponentTagsEnableSeparateBackground.ts
+++ b/src/setting_tab/components/ComponentTagsEnableSeparateBackground.ts
@@ -13,7 +13,7 @@ export class ComponentTagsEnableSeparateBackground extends SettingsTabComponent 
 	public create_component(containerEL:HTMLElement): Setting {
 		return new Setting(containerEL)
 			.setName("Enable separate background color")
-			.setDesc("Allows you to specify a different background color for each tag")
+			.setDesc("Allows you to specify a different background color for each tag.")
 			.addToggle(component => {
 					component
 						.setValue(this.plugin.settings.TagColors.EnableSeparateBackground)

--- a/src/setting_tab/components/ComponentTagsEnableSeparateLuminance.ts
+++ b/src/setting_tab/components/ComponentTagsEnableSeparateLuminance.ts
@@ -6,22 +6,19 @@ import {SettingsTabComponent} from "src/setting_tab/SettingsTabComponent";
 // ---------------------------------------------------------------------------------------------------------------------
 // Code
 // ---------------------------------------------------------------------------------------------------------------------
-export class ComponentTagsCanvas extends SettingsTabComponent {
+export class ComponentTagsEnableSeparateLuminance extends SettingsTabComponent {
 	// -----------------------------------------------------------------------------------------------------------------
 	// methods
 	// -----------------------------------------------------------------------------------------------------------------
 	public create_component(containerEL:HTMLElement): Setting {
 		return new Setting(containerEL)
-			.setName("Apply tag color to canvas card")
-			.setDesc(`
-			Applies the tag color, of the tag within the canvas's card, to the background color of the canvas card.
-			The Value slider and setter to the right, are the luminance offsets for the background.
-			`)
+			.setName("Enable separate luminance offsets per tag")
+			.setDesc("Allows you to specify a different luminance offset value for each tag. This offset is used in background of items like Canvas Card, Kanban Card/List, ...")
 			.addToggle(component => {
 					component
-						.setValue(this.plugin.settings.Canvas.Enable)
+						.setValue(this.plugin.settings.TagColors.EnableSeparateLuminanceOffset)
 						.onChange(async state => {
-							this.plugin.settings.Canvas.Enable = state;
+							this.plugin.settings.TagColors.EnableSeparateLuminanceOffset = state;
 							await this.plugin.saveSettings();
 							this.settings_tab.display();
 						})

--- a/src/setting_tab/components/index.ts
+++ b/src/setting_tab/components/index.ts
@@ -17,3 +17,4 @@ export * from 'src/setting_tab/components/ComponentTagsEnableSeparateBackground'
 export * from 'src/setting_tab/components/ComponentKanbanHideHashtags';
 export * from 'src/setting_tab/components/ComponentTagsEnableSeparateLuminance';
 export * from 'src/setting_tab/components/ComponentTagsEnableDarkLightDifference';
+export * from 'src/setting_tab/components/ComponentTagsEnableBackgroundOpacity';

--- a/src/setting_tab/components/index.ts
+++ b/src/setting_tab/components/index.ts
@@ -16,3 +16,4 @@ export * from 'src/setting_tab/components/ComponentTagsEnableMultipleTags';
 export * from 'src/setting_tab/components/ComponentTagsEnableSeparateBackground';
 export * from 'src/setting_tab/components/ComponentKanbanHideHashtags';
 export * from 'src/setting_tab/components/ComponentTagsEnableSeparateLuminance';
+export * from 'src/setting_tab/components/ComponentTagsEnableDarkLightDifference';

--- a/src/setting_tab/components/index.ts
+++ b/src/setting_tab/components/index.ts
@@ -15,3 +15,4 @@ export * from 'src/setting_tab/components/ComponentFolderNoteFolderTagLinks';
 export * from 'src/setting_tab/components/ComponentTagsEnableMultipleTags';
 export * from 'src/setting_tab/components/ComponentTagsEnableSeparateBackground';
 export * from 'src/setting_tab/components/ComponentKanbanHideHashtags';
+export * from 'src/setting_tab/components/ComponentTagsEnableSeparateLuminance';

--- a/src/settings/DefaultSettings.ts
+++ b/src/settings/DefaultSettings.ts
@@ -14,6 +14,7 @@ export interface IColoredTagWranglerSettings {
 		EnableMultipleTags:boolean,
 		EnableSeparateBackground:boolean,
 		EnableSeparateLuminanceOffset:boolean,
+		EnableDarkLightDifference:boolean,
 		Values:{
 			BackgroundOpacity:number,
 			BackgroundOpacityHover:number,
@@ -72,7 +73,7 @@ export const DefaultSettings: IColoredTagWranglerSettings = {
 		EnableMultipleTags:true,
 		EnableSeparateBackground:false,
 		EnableSeparateLuminanceOffset:false,
-
+		EnableDarkLightDifference:true,
 		Values:{
 			BackgroundOpacity:0.2,
 			BackgroundOpacityHover:0.1,

--- a/src/settings/DefaultSettings.ts
+++ b/src/settings/DefaultSettings.ts
@@ -15,9 +15,9 @@ export interface IColoredTagWranglerSettings {
 		EnableSeparateBackground:boolean,
 		EnableSeparateLuminanceOffset:boolean,
 		EnableDarkLightDifference:boolean,
+		EnableBackgroundOpacity:boolean,
 		Values:{
 			BackgroundOpacity:number,
-			BackgroundOpacityHover:number,
 			LuminanceOffset:number,
 		}
 	},
@@ -74,9 +74,9 @@ export const DefaultSettings: IColoredTagWranglerSettings = {
 		EnableSeparateBackground:false,
 		EnableSeparateLuminanceOffset:false,
 		EnableDarkLightDifference:true,
+		EnableBackgroundOpacity:false,
 		Values:{
 			BackgroundOpacity:0.2,
-			BackgroundOpacityHover:0.1,
 			LuminanceOffset:0.15
 		}
 	},

--- a/src/settings/DefaultSettings.ts
+++ b/src/settings/DefaultSettings.ts
@@ -9,14 +9,15 @@ import {RGB}
 // ---------------------------------------------------------------------------------------------------------------------
 export interface IColoredTagWranglerSettings {
 	TagColors:{
-		ColorPicker: Record<string, {tag_name:string, color:RGB, background_color:RGB,background_opacity:number}>,
+		ColorPicker: Record<string, {tag_name:string, color:RGB, background_color:RGB,luminance_offset:number}>,
 
 		EnableMultipleTags:boolean,
 		EnableSeparateBackground:boolean,
+		EnableSeparateLuminanceOffset:boolean,
 		Values:{
 			BackgroundOpacity:number,
 			BackgroundOpacityHover:number,
-			SemanticColorsLuminanceOffset:number,
+			LuminanceOffset:number,
 		}
 	},
 
@@ -70,11 +71,12 @@ export const DefaultSettings: IColoredTagWranglerSettings = {
 
 		EnableMultipleTags:true,
 		EnableSeparateBackground:false,
+		EnableSeparateLuminanceOffset:false,
 
 		Values:{
 			BackgroundOpacity:0.2,
 			BackgroundOpacityHover:0.1,
-			SemanticColorsLuminanceOffset:0.35
+			LuminanceOffset:0.15
 		}
 	},
 
@@ -112,10 +114,10 @@ export const DefaultSettings: IColoredTagWranglerSettings = {
 
 		Values:{
 			CardBorderOpacity:0.3,
-			CardBackgroundLuminanceOffset:0.35,
+			CardBackgroundLuminanceOffset:0.15,
 		}
 	},
 	Info: {
-		SettingsVersion: 6 // UPDATE THIS WHEN YOU CHANGE ANYTHING IN THE SETTINGS!!!
+		SettingsVersion: 7 // UPDATE THIS WHEN YOU CHANGE ANYTHING IN THE SETTINGS!!!
 	}
 }

--- a/src/settings/Migrate.ts
+++ b/src/settings/Migrate.ts
@@ -7,7 +7,8 @@ import {
     migrate_2_to_3,
     migrate_3_to_4,
     migrate_4_to_5,
-    migrate_5_to_6
+    migrate_5_to_6,
+    migrate_6_to_7
 } from "src/settings/migrations";
 import {IColoredTagWranglerSettings} from "./DefaultSettings";
 // ---------------------------------------------------------------------------------------------------------------------
@@ -23,6 +24,7 @@ const MIGRATION_STEPS: ((data: any) => any)[] = [ // Using any's isn't perfect b
     (data) => migrate_3_to_4(data),
     (data) => migrate_4_to_5(data),
     (data) => migrate_5_to_6(data),
+    (data) => migrate_6_to_7(data),
 ];
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/src/settings/migrations/index.ts
+++ b/src/settings/migrations/index.ts
@@ -4,3 +4,4 @@ export * from './migrate_2_to_3';
 export * from './migrate_3_to_4';
 export * from './migrate_4_to_5';
 export * from './migrate_5_to_6';
+export * from './migrate_6_to_7';

--- a/src/settings/migrations/migrate_5_to_6.ts
+++ b/src/settings/migrations/migrate_5_to_6.ts
@@ -1,20 +1,19 @@
 // ---------------------------------------------------------------------------------------------------------------------
 // Imports
 // ---------------------------------------------------------------------------------------------------------------------
-import {IColoredTagWranglerSettings}
-    from "../DefaultSettings";
 import {ISettings_v005}
     from "../old_setting_versions/ISettings_v005";
+import {ISettings_v006} from "../old_setting_versions/ISettings_v006";
 // ---------------------------------------------------------------------------------------------------------------------
 // Code
 // ---------------------------------------------------------------------------------------------------------------------
-export function migrate_5_to_6(loaded_data:ISettings_v005):IColoredTagWranglerSettings {
-    let transformed_data = loaded_data as unknown as IColoredTagWranglerSettings;
+export function migrate_5_to_6(loaded_data:ISettings_v005):ISettings_v006 {
+    let transformed_data = loaded_data as unknown as ISettings_v006;
 
     // Fixes mistake
     transformed_data.Kanban.HideHashtags = loaded_data.Kanban.Enable
 
     transformed_data.Info.SettingsVersion = 6;
-    return transformed_data as unknown as IColoredTagWranglerSettings;
+    return transformed_data;
 
 }

--- a/src/settings/migrations/migrate_6_to_7.ts
+++ b/src/settings/migrations/migrate_6_to_7.ts
@@ -5,6 +5,8 @@ import {IColoredTagWranglerSettings}
     from "../DefaultSettings";
 import {ISettings_v006}
     from "../old_setting_versions/ISettings_v006";
+import {RGB} from "obsidian";
+import {hslToRgb, rgbToHsl} from "../../lib";
 // ---------------------------------------------------------------------------------------------------------------------
 // Code
 // ---------------------------------------------------------------------------------------------------------------------
@@ -19,7 +21,9 @@ export function migrate_6_to_7(loaded_data:ISettings_v006):IColoredTagWranglerSe
         transformed_data.TagColors.ColorPicker[tagUUID] = {
             tag_name:old_record.tag_name,
             color:old_record.color,
-            background_color:old_record.background_color,
+            background_color:checkColor(old_record.background_color, old_record.color)
+                ? callback_fix_background(old_record.background_color, transformed_data.TagColors.Values.LuminanceOffset)
+                : old_record.background_color,
             luminance_offset:transformed_data.TagColors.Values.LuminanceOffset,
         }
     }
@@ -27,4 +31,20 @@ export function migrate_6_to_7(loaded_data:ISettings_v006):IColoredTagWranglerSe
     transformed_data.Info.SettingsVersion = 7;
     return transformed_data as unknown as IColoredTagWranglerSettings;
 
+}
+
+function checkColor(color:RGB, background:RGB):boolean{
+    let check = (
+        color.r === background.r
+        && color.g === background.g
+        && color.b === background.b
+    )
+    console.warn({color, background, check})
+    return check
+}
+
+function callback_fix_background(background:RGB, luminance_offset:number):RGB{
+    let background_hsl = rgbToHsl(background)
+    background_hsl.l -= luminance_offset
+    return hslToRgb(background_hsl)
 }

--- a/src/settings/migrations/migrate_6_to_7.ts
+++ b/src/settings/migrations/migrate_6_to_7.ts
@@ -45,6 +45,6 @@ function checkColor(color:RGB, background:RGB):boolean{
 
 function callback_fix_background(background:RGB, luminance_offset:number):RGB{
     let background_hsl = rgbToHsl(background)
-    background_hsl.l -= luminance_offset
+    background_hsl.l -=  2 * (background_hsl.l / 3);
     return hslToRgb(background_hsl)
 }

--- a/src/settings/migrations/migrate_6_to_7.ts
+++ b/src/settings/migrations/migrate_6_to_7.ts
@@ -1,0 +1,30 @@
+// ---------------------------------------------------------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------------------------------------------------------
+import {IColoredTagWranglerSettings}
+    from "../DefaultSettings";
+import {ISettings_v006}
+    from "../old_setting_versions/ISettings_v006";
+// ---------------------------------------------------------------------------------------------------------------------
+// Code
+// ---------------------------------------------------------------------------------------------------------------------
+export function migrate_6_to_7(loaded_data:ISettings_v006):IColoredTagWranglerSettings {
+    let transformed_data = loaded_data as unknown as IColoredTagWranglerSettings;
+
+    // Fixes mistake
+    for (const tagUUID of Object.keys(loaded_data.TagColors.ColorPicker)){
+        let old_record = loaded_data.TagColors.ColorPicker[tagUUID];
+        transformed_data.TagColors.ColorPicker[tagUUID] = {
+            tag_name:old_record.tag_name,
+            color:old_record.color,
+            background_color:old_record.background_color,
+            luminance_offset:old_record.background_opacity,
+        }
+    }
+    transformed_data.TagColors.EnableSeparateLuminanceOffset = false;
+    transformed_data.TagColors.Values.LuminanceOffset = loaded_data.TagColors.Values.SemanticColorsLuminanceOffset;
+
+    transformed_data.Info.SettingsVersion = 7;
+    return transformed_data as unknown as IColoredTagWranglerSettings;
+
+}

--- a/src/settings/migrations/migrate_6_to_7.ts
+++ b/src/settings/migrations/migrate_6_to_7.ts
@@ -15,6 +15,8 @@ export function migrate_6_to_7(loaded_data:ISettings_v006):IColoredTagWranglerSe
     transformed_data.TagColors.Values.LuminanceOffset = 0.15;
     transformed_data.TagColors.EnableSeparateLuminanceOffset = false;
     transformed_data.TagColors.EnableDarkLightDifference = true;
+    transformed_data.TagColors.EnableBackgroundOpacity = false;
+    transformed_data.TagColors.Values.BackgroundOpacity = 0.2;
 
     // Fixes mistake
     for (const tagUUID of Object.keys(loaded_data.TagColors.ColorPicker)){

--- a/src/settings/migrations/migrate_6_to_7.ts
+++ b/src/settings/migrations/migrate_6_to_7.ts
@@ -10,6 +10,8 @@ import {ISettings_v006}
 // ---------------------------------------------------------------------------------------------------------------------
 export function migrate_6_to_7(loaded_data:ISettings_v006):IColoredTagWranglerSettings {
     let transformed_data = loaded_data as unknown as IColoredTagWranglerSettings;
+    transformed_data.TagColors.Values.LuminanceOffset = 0.15;
+    transformed_data.TagColors.EnableSeparateLuminanceOffset = false;
 
     // Fixes mistake
     for (const tagUUID of Object.keys(loaded_data.TagColors.ColorPicker)){
@@ -18,11 +20,9 @@ export function migrate_6_to_7(loaded_data:ISettings_v006):IColoredTagWranglerSe
             tag_name:old_record.tag_name,
             color:old_record.color,
             background_color:old_record.background_color,
-            luminance_offset:old_record.background_opacity,
+            luminance_offset:transformed_data.TagColors.Values.LuminanceOffset,
         }
     }
-    transformed_data.TagColors.EnableSeparateLuminanceOffset = false;
-    transformed_data.TagColors.Values.LuminanceOffset = 0.15;
 
     transformed_data.Info.SettingsVersion = 7;
     return transformed_data as unknown as IColoredTagWranglerSettings;

--- a/src/settings/migrations/migrate_6_to_7.ts
+++ b/src/settings/migrations/migrate_6_to_7.ts
@@ -45,6 +45,6 @@ function checkColor(color:RGB, background:RGB):boolean{
 
 function callback_fix_background(background:RGB, luminance_offset:number):RGB{
     let background_hsl = rgbToHsl(background)
-    background_hsl.l -=  2 * (background_hsl.l / 3);
+    background_hsl.l -= luminance_offset
     return hslToRgb(background_hsl)
 }

--- a/src/settings/migrations/migrate_6_to_7.ts
+++ b/src/settings/migrations/migrate_6_to_7.ts
@@ -14,6 +14,7 @@ export function migrate_6_to_7(loaded_data:ISettings_v006):IColoredTagWranglerSe
     let transformed_data = loaded_data as unknown as IColoredTagWranglerSettings;
     transformed_data.TagColors.Values.LuminanceOffset = 0.15;
     transformed_data.TagColors.EnableSeparateLuminanceOffset = false;
+    transformed_data.TagColors.EnableDarkLightDifference = true;
 
     // Fixes mistake
     for (const tagUUID of Object.keys(loaded_data.TagColors.ColorPicker)){

--- a/src/settings/migrations/migrate_6_to_7.ts
+++ b/src/settings/migrations/migrate_6_to_7.ts
@@ -22,7 +22,7 @@ export function migrate_6_to_7(loaded_data:ISettings_v006):IColoredTagWranglerSe
         }
     }
     transformed_data.TagColors.EnableSeparateLuminanceOffset = false;
-    transformed_data.TagColors.Values.LuminanceOffset = loaded_data.TagColors.Values.SemanticColorsLuminanceOffset;
+    transformed_data.TagColors.Values.LuminanceOffset = 0.15;
 
     transformed_data.Info.SettingsVersion = 7;
     return transformed_data as unknown as IColoredTagWranglerSettings;

--- a/src/settings/old_setting_versions/ISettings_v006.ts
+++ b/src/settings/old_setting_versions/ISettings_v006.ts
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------------------------------------------------------
+import {RGB}
+	from "obsidian";
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------------------------------------------------
+export interface ISettings_v006 {
+	TagColors:{
+		ColorPicker: Record<string, {tag_name:string, color:RGB, background_color:RGB,background_opacity:number}>,
+
+		EnableMultipleTags:boolean,
+		EnableSeparateBackground:boolean,
+		Values:{
+			BackgroundOpacity:number,
+			BackgroundOpacityHover:number,
+			SemanticColorsLuminanceOffset:number,
+		}
+	},
+
+	FolderNote:{
+		Enable:boolean
+		FolderTagLinks:Record<string, {folder_path:string, tag_name:string}>,
+
+		Values:{
+			ForceImportant:boolean,
+			BorderRadius:string,
+			Padding:string,
+		}
+	},
+
+	Kanban:{
+		Enable: boolean,
+		EnableCards:boolean,
+		EnableLists:boolean,
+		HideHashtags:boolean,
+
+		Values:{
+			CardBackgroundOpacity:number,
+			CardBorderOpacity:number,
+			ListBackgroundOpacity:number,
+			ListBorderOpacity:number,
+		},
+	},
+
+	Debug:{
+		Enable:boolean,
+	},
+
+	Canvas:{
+		Enable:boolean,
+
+		Values:{
+			CardBorderOpacity:number,
+			CardBackgroundLuminanceOffset:number,
+		},
+	},
+	Info: {
+		SettingsVersion: number
+	}
+}

--- a/src/style_manager/wranglers/StyleWrangler.ts
+++ b/src/style_manager/wranglers/StyleWrangler.ts
@@ -1,7 +1,7 @@
 // ---------------------------------------------------------------------------------------------------------------------
 // Imports
 // ---------------------------------------------------------------------------------------------------------------------
-import {removeById}
+import {hslToRgb, removeById, rgbToHsl}
 	from "src/lib";
 import ColoredTagWranglerPlugin
 	from "src/main";
@@ -21,6 +21,7 @@ export interface IStyleWrangler{
 	apply_styles(): void;
 	remove_styles(): void;
 	get_tags():Array<{tag_name:string, color:RGB, background_color:RGB, luminance_offset:number}>;
+	get_background_color(background_color:RGB, luminance_offset:number, is_light_theme:boolean):RGB;
 }
 // ---------------------------------------------------------------------------------------------------------------------
 // Interface
@@ -79,5 +80,14 @@ export abstract class StyleWrangler implements IStyleWrangler{
 				}
 			})
 			.flat();
+	}
+
+	get_background_color(background_color:RGB, luminance_offset:number, is_light_theme:boolean):RGB{
+		if (is_light_theme && this.plugin.settings.TagColors.EnableDarkLightDifference ){
+			luminance_offset = -luminance_offset; // Double negative => +
+		}
+		let background_hsl = rgbToHsl(background_color);
+		background_hsl.l -= luminance_offset;
+		return hslToRgb(background_hsl);
 	}
 }

--- a/src/style_manager/wranglers/StyleWrangler.ts
+++ b/src/style_manager/wranglers/StyleWrangler.ts
@@ -22,6 +22,7 @@ export interface IStyleWrangler{
 	remove_styles(): void;
 	get_tags():Array<{tag_name:string, color:RGB, background_color:RGB, luminance_offset:number}>;
 	get_background_color(background_color:RGB, luminance_offset:number, is_light_theme:boolean):RGB;
+	get_background_string(color:RGB):string;
 }
 // ---------------------------------------------------------------------------------------------------------------------
 // Interface
@@ -89,5 +90,15 @@ export abstract class StyleWrangler implements IStyleWrangler{
 		let background_hsl = rgbToHsl(background_color);
 		background_hsl.l -= luminance_offset;
 		return hslToRgb(background_hsl);
+	}
+
+	get_background_string(color:RGB):string{
+		let rgb = this.plugin.settings.TagColors.EnableBackgroundOpacity
+			?  "rgba"
+			: "rgb";
+		let opacity = this.plugin.settings.TagColors.EnableBackgroundOpacity
+			?  `, ${this.plugin.settings.TagColors.Values.BackgroundOpacity}`
+			: "";
+		return `${rgb}(${color.r}, ${color.g}, ${color.b}${opacity})`
 	}
 }

--- a/src/style_manager/wranglers/StyleWrangler.ts
+++ b/src/style_manager/wranglers/StyleWrangler.ts
@@ -20,7 +20,7 @@ export interface IStyleWrangler{
 	assemble_css_dark():Array<string>;
 	apply_styles(): void;
 	remove_styles(): void;
-	get_tags():Array<{tag_name:string, color:RGB, background_color:RGB, background_opacity:number}>;
+	get_tags():Array<{tag_name:string, color:RGB, background_color:RGB, luminance_offset:number}>;
 }
 // ---------------------------------------------------------------------------------------------------------------------
 // Interface
@@ -66,16 +66,16 @@ export abstract class StyleWrangler implements IStyleWrangler{
 		removeById(this.id);
 	};
 
-	get_tags():Array<{tag_name:string, color:RGB, background_color:RGB, background_opacity:number}>{
+	get_tags():Array<{tag_name:string, color:RGB, background_color:RGB, luminance_offset:number}>{
 		return Object.keys(this.plugin.settings?.TagColors.ColorPicker)
 			.map(tagUUID => {
-				const {tag_name, color, background_color, background_opacity} = this.plugin.settings.TagColors.ColorPicker[tagUUID];
+				const {tag_name, color, background_color, luminance_offset} = this.plugin.settings.TagColors.ColorPicker[tagUUID];
 				if (this.plugin.settings?.TagColors.EnableMultipleTags) {
 					return tag_name.split(";").map(tag => {
-						return {tag_name: tag, color, background_color, background_opacity};
+						return {tag_name: tag, color, background_color, luminance_offset};
 					})
 				} else {
-					return {tag_name: tag_name, color, background_color, background_opacity};
+					return {tag_name: tag_name, color, background_color, luminance_offset};
 				}
 			})
 			.flat();

--- a/src/style_manager/wranglers/StyleWranglerFolderNote.ts
+++ b/src/style_manager/wranglers/StyleWranglerFolderNote.ts
@@ -31,20 +31,19 @@ export class StyleWranglerFolderNote extends StyleWrangler {
 					let {folder_path, tag_name:folder_tag_name} = this.plugin.settings.FolderNote.FolderTagLinks[folderUUID];
 					return all_tags
 						.filter(({tag_name:known_tag})=>known_tag===folder_tag_name)
-						.map(({color, background_color:bcolor, background_opacity}) => {
+						.map(({color, background_color, luminance_offset}) => {
 							// noinspection CssInvalidFunction,CssUnusedSymbol,CssInvalidPropertyValue
 							return this.assemble_css(
 								"body.theme-light",
 								folder_path,
 								color,
-								bcolor,
+								background_color,
 								important,
-								background_opacity,
+								luminance_offset,
 								border_radius,
 								padding
 							)
 						})
-						.flat()
 				}
 			)
 			.flat()
@@ -62,26 +61,25 @@ export class StyleWranglerFolderNote extends StyleWrangler {
 					let {folder_path, tag_name:folder_tag_name} = this.plugin.settings.FolderNote.FolderTagLinks[folderUUID];
 					return all_tags
 						.filter(({tag_name:known_tag})=>known_tag===folder_tag_name)
-						.map(({color, background_color:bcolor, background_opacity}) => {
+						.map(({color, background_color, luminance_offset}) => {
 							// noinspection CssInvalidFunction,CssUnusedSymbol,CssInvalidPropertyValue
 							return this.assemble_css(
 								"body.theme-dark",
 								folder_path,
 								color,
-								bcolor,
+								background_color,
 								important,
-								background_opacity,
+								luminance_offset,
 								border_radius,
 								padding
 							)
 						})
-						.flat()
 				}
 			)
 			.flat()
 	}
 
-	private assemble_css(theme:string, folder_path:string, color:RGB, bcolor:RGB, important:string, background_opacity:number, border_radius:string, padding:string){
+	private assemble_css(theme:string, folder_path:string, color:RGB, bcolor:RGB, important:string, luminance_offset:number, border_radius:string, padding:string){
 		return`
 /* Apply color to drop down triangle */
 ${theme} div.nav-folder-title[data-path="${folder_path}"] svg.svg-icon.right-triangle{
@@ -109,7 +107,7 @@ ${theme} .nav-folder:has(> [data-path="${folder_path}"]) .nav-folder-children {
 
 /* Apply color to folder title and background*/
 ${theme} .nav-folder:has(> [data-path="${folder_path}"]){
-	background-color: rgba(${bcolor.r}, ${bcolor.g}, ${bcolor.b},  ${background_opacity}) ${important};								
+	background-color: rgb(${bcolor.r}, ${bcolor.g}, ${bcolor.b}) ${important};								
 	border-radius: ${border_radius};
 	padding: ${padding};
 	margin-bottom: ${padding};

--- a/src/style_manager/wranglers/StyleWranglerFolderNote.ts
+++ b/src/style_manager/wranglers/StyleWranglerFolderNote.ts
@@ -5,7 +5,8 @@ import {StyleWrangler}
 	from "src/style_manager/wranglers/StyleWrangler";
 import ColoredTagWranglerPlugin
 	from "src/main";
-import {HSL, RGB} from "obsidian";
+import {RGB}
+	from "obsidian";
 // ---------------------------------------------------------------------------------------------------------------------
 // Code
 // ---------------------------------------------------------------------------------------------------------------------
@@ -114,7 +115,7 @@ ${theme} .nav-folder:has(> [data-path="${folder_path}"]) .nav-folder-children {
 
 /* Apply color to folder title and background*/
 ${theme} .nav-folder:has(> [data-path="${folder_path}"]){
-	background-color: rgb(${background.r}, ${background.g}, ${background.b}) ${important};								
+	background-color: ${this.get_background_string(background)} ${important};								
 	border-radius: ${border_radius};
 	padding: ${padding};
 	margin-bottom: ${padding};

--- a/src/style_manager/wranglers/StyleWranglerFolderNote.ts
+++ b/src/style_manager/wranglers/StyleWranglerFolderNote.ts
@@ -36,7 +36,7 @@ export class StyleWranglerFolderNote extends StyleWrangler {
 							// noinspection CssInvalidFunction,CssUnusedSymbol,CssInvalidPropertyValue
 
 							let background_hsl = rgbToHsl(background_color);
-							background_hsl.l -= luminance_offset;
+							background_hsl.l += luminance_offset;
 
 							return this.assemble_css(
 								"body.theme-light",

--- a/src/style_manager/wranglers/StyleWranglerFolderNote.ts
+++ b/src/style_manager/wranglers/StyleWranglerFolderNote.ts
@@ -5,7 +5,8 @@ import {StyleWrangler}
 	from "src/style_manager/wranglers/StyleWrangler";
 import ColoredTagWranglerPlugin
 	from "src/main";
-import {RGB} from "obsidian";
+import {HSL, RGB} from "obsidian";
+import {hslToRgb, rgbToHsl} from "../../lib";
 // ---------------------------------------------------------------------------------------------------------------------
 // Code
 // ---------------------------------------------------------------------------------------------------------------------
@@ -33,13 +34,16 @@ export class StyleWranglerFolderNote extends StyleWrangler {
 						.filter(({tag_name:known_tag})=>known_tag===folder_tag_name)
 						.map(({color, background_color, luminance_offset}) => {
 							// noinspection CssInvalidFunction,CssUnusedSymbol,CssInvalidPropertyValue
+
+							let background_hsl = rgbToHsl(background_color);
+							background_hsl.l -= luminance_offset;
+
 							return this.assemble_css(
 								"body.theme-light",
 								folder_path,
 								color,
-								background_color,
+								hslToRgb(background_hsl),
 								important,
-								luminance_offset,
 								border_radius,
 								padding
 							)
@@ -55,6 +59,7 @@ export class StyleWranglerFolderNote extends StyleWrangler {
 		let important = this.plugin.settings.FolderNote.Values.ForceImportant ? "!important" : ""
 		let border_radius = this.plugin.settings.FolderNote.Values.BorderRadius
 		let padding = this.plugin.settings.FolderNote.Values.Padding
+
 		return Object.keys(this.plugin.settings.FolderNote.FolderTagLinks)
 			.map(
 				folderUUID => {
@@ -63,13 +68,16 @@ export class StyleWranglerFolderNote extends StyleWrangler {
 						.filter(({tag_name:known_tag})=>known_tag===folder_tag_name)
 						.map(({color, background_color, luminance_offset}) => {
 							// noinspection CssInvalidFunction,CssUnusedSymbol,CssInvalidPropertyValue
+
+							let background_hsl = rgbToHsl(background_color);
+							background_hsl.l -= luminance_offset;
+
 							return this.assemble_css(
 								"body.theme-dark",
 								folder_path,
 								color,
-								background_color,
+								hslToRgb(background_hsl),
 								important,
-								luminance_offset,
 								border_radius,
 								padding
 							)
@@ -79,7 +87,7 @@ export class StyleWranglerFolderNote extends StyleWrangler {
 			.flat()
 	}
 
-	private assemble_css(theme:string, folder_path:string, color:RGB, bcolor:RGB, important:string, luminance_offset:number, border_radius:string, padding:string){
+	private assemble_css(theme:string, folder_path:string, color:RGB, background:RGB, important:string, border_radius:string, padding:string){
 		return`
 /* Apply color to drop down triangle */
 ${theme} div.nav-folder-title[data-path="${folder_path}"] svg.svg-icon.right-triangle{
@@ -101,13 +109,13 @@ ${theme} div.nav-folder:has(> [data-path="${folder_path}"]) .nav-file-title-cont
 
 /* Applies color to the bar next to the notes in the folder*/
 ${theme} .nav-folder:has(> [data-path="${folder_path}"]) .nav-folder-children {
-	border-left-color: rgba(${color.r}, ${color.g}, ${color.b},  0.2) ${important};
+	border-left-color: rgb(${color.r}, ${color.g}, ${color.b}) ${important};
 	border-left-width: 2px ${important};
 }
 
 /* Apply color to folder title and background*/
 ${theme} .nav-folder:has(> [data-path="${folder_path}"]){
-	background-color: rgb(${bcolor.r}, ${bcolor.g}, ${bcolor.b}) ${important};								
+	background-color: rgb(${background.r}, ${background.g}, ${background.b}) ${important};								
 	border-radius: ${border_radius};
 	padding: ${padding};
 	margin-bottom: ${padding};

--- a/src/style_manager/wranglers/StyleWranglerFolderNote.ts
+++ b/src/style_manager/wranglers/StyleWranglerFolderNote.ts
@@ -6,7 +6,6 @@ import {StyleWrangler}
 import ColoredTagWranglerPlugin
 	from "src/main";
 import {HSL, RGB} from "obsidian";
-import {hslToRgb, rgbToHsl} from "../../lib";
 // ---------------------------------------------------------------------------------------------------------------------
 // Code
 // ---------------------------------------------------------------------------------------------------------------------
@@ -34,15 +33,15 @@ export class StyleWranglerFolderNote extends StyleWrangler {
 						.filter(({tag_name:known_tag})=>known_tag===folder_tag_name)
 						.map(({color, background_color, luminance_offset}) => {
 							// noinspection CssInvalidFunction,CssUnusedSymbol,CssInvalidPropertyValue
-
-							let background_hsl = rgbToHsl(background_color);
-							background_hsl.l += luminance_offset;
-
 							return this.assemble_css(
 								"body.theme-light",
 								folder_path,
 								color,
-								hslToRgb(background_hsl),
+								this.get_background_color(
+									background_color,
+									luminance_offset,
+									true
+								),
 								important,
 								border_radius,
 								padding
@@ -68,15 +67,15 @@ export class StyleWranglerFolderNote extends StyleWrangler {
 						.filter(({tag_name:known_tag})=>known_tag===folder_tag_name)
 						.map(({color, background_color, luminance_offset}) => {
 							// noinspection CssInvalidFunction,CssUnusedSymbol,CssInvalidPropertyValue
-
-							let background_hsl = rgbToHsl(background_color);
-							background_hsl.l -= luminance_offset;
-
 							return this.assemble_css(
 								"body.theme-dark",
 								folder_path,
 								color,
-								hslToRgb(background_hsl),
+								this.get_background_color(
+									background_color,
+									luminance_offset,
+									false
+								),
 								important,
 								border_radius,
 								padding

--- a/src/style_manager/wranglers/StyleWranglerKanbanCards.ts
+++ b/src/style_manager/wranglers/StyleWranglerKanbanCards.ts
@@ -6,7 +6,7 @@ import {StyleWrangler}
 import ColoredTagWranglerPlugin
 	from "src/main";
 import {RGB} from "obsidian";
-import {rgbToHsl} from "../../lib";
+import {hslToRgb, rgbToHsl} from "../../lib";
 // ---------------------------------------------------------------------------------------------------------------------
 // Code
 // ---------------------------------------------------------------------------------------------------------------------
@@ -26,13 +26,15 @@ export class StyleWranglerKanbanCards extends StyleWrangler {
 		return this.get_tags()
 			.map(
 				({tag_name, color, background_color,luminance_offset}) => {
+
+					let background_hsl = rgbToHsl(background_color);
+					background_hsl.l -= luminance_offset;
+
 					return this.assemble_css(
 						"body.theme-light",
 						tag_name,
 						color,
-						background_color,
-						luminance_offset,
-						opacity_border,
+						hslToRgb(background_hsl)
 					)
 				});
 	}
@@ -43,24 +45,26 @@ export class StyleWranglerKanbanCards extends StyleWrangler {
 		return this.get_tags()
 			.map(
 				({tag_name, color, background_color,luminance_offset}) => {
+
+					let background_hsl = rgbToHsl(background_color);
+					background_hsl.l -= luminance_offset;
+
 					return this.assemble_css(
 						"body.theme-dark",
 						tag_name,
 						color,
-						background_color,
-						luminance_offset,
-						opacity_border,
+						hslToRgb(background_hsl)
 					)
 				});
 	}
 
-	private assemble_css(theme:string, tag_name:string, color:RGB, background_color:RGB, luminance_offset:number, opacity_border:number){
+	private assemble_css(theme:string, tag_name:string, color:RGB, background_color:RGB){
 		return`
 ${theme} div.kanban-plugin__item.has-tag-${tag_name} div.kanban-plugin__item-title-wrapper { 
 	background: rgb(${background_color.r}, ${background_color.g}, ${background_color.b}) !important;
 }
 ${theme} div.kanban-plugin__item.has-tag-${tag_name}{ 
-	border-color: rgba(${color.r}, ${color.g}, ${color.b}, ${opacity_border}) !important;
+	border-color: rgb(${color.r}, ${color.g}, ${color.b}) !important;
 }`
 
 	}

--- a/src/style_manager/wranglers/StyleWranglerKanbanCards.ts
+++ b/src/style_manager/wranglers/StyleWranglerKanbanCards.ts
@@ -6,6 +6,7 @@ import {StyleWrangler}
 import ColoredTagWranglerPlugin
 	from "src/main";
 import {RGB} from "obsidian";
+import {rgbToHsl} from "../../lib";
 // ---------------------------------------------------------------------------------------------------------------------
 // Code
 // ---------------------------------------------------------------------------------------------------------------------
@@ -24,13 +25,13 @@ export class StyleWranglerKanbanCards extends StyleWrangler {
 
 		return this.get_tags()
 			.map(
-				({tag_name, color, background_color,background_opacity}) => {
+				({tag_name, color, background_color,luminance_offset}) => {
 					return this.assemble_css(
 						"body.theme-light",
 						tag_name,
 						color,
 						background_color,
-						background_opacity,
+						luminance_offset,
 						opacity_border,
 					)
 				});
@@ -41,22 +42,22 @@ export class StyleWranglerKanbanCards extends StyleWrangler {
 
 		return this.get_tags()
 			.map(
-				({tag_name, color, background_color,background_opacity}) => {
+				({tag_name, color, background_color,luminance_offset}) => {
 					return this.assemble_css(
 						"body.theme-dark",
 						tag_name,
 						color,
 						background_color,
-						background_opacity,
+						luminance_offset,
 						opacity_border,
 					)
 				});
 	}
 
-	private assemble_css(theme:string, tag_name:string, color:RGB, background_color:RGB, background_opacity:number, opacity_border:number){
+	private assemble_css(theme:string, tag_name:string, color:RGB, background_color:RGB, luminance_offset:number, opacity_border:number){
 		return`
 ${theme} div.kanban-plugin__item.has-tag-${tag_name} div.kanban-plugin__item-title-wrapper { 
-	background: rgba(${background_color.r}, ${background_color.g}, ${background_color.b}, ${background_opacity}) !important;
+	background: rgb(${background_color.r}, ${background_color.g}, ${background_color.b}) !important;
 }
 ${theme} div.kanban-plugin__item.has-tag-${tag_name}{ 
 	border-color: rgba(${color.r}, ${color.g}, ${color.b}, ${opacity_border}) !important;

--- a/src/style_manager/wranglers/StyleWranglerKanbanCards.ts
+++ b/src/style_manager/wranglers/StyleWranglerKanbanCards.ts
@@ -24,15 +24,15 @@ export class StyleWranglerKanbanCards extends StyleWrangler {
 		return this.get_tags()
 			.map(
 				({tag_name, color, background_color,luminance_offset}) => {
-
-					let background_hsl = rgbToHsl(background_color);
-					background_hsl.l += luminance_offset;
-
 					return this.assemble_css(
 						"body.theme-light",
 						tag_name,
 						color,
-						hslToRgb(background_hsl)
+						this.get_background_color(
+							background_color,
+							luminance_offset,
+							true
+						)
 					)
 				});
 	}
@@ -41,15 +41,15 @@ export class StyleWranglerKanbanCards extends StyleWrangler {
 		return this.get_tags()
 			.map(
 				({tag_name, color, background_color,luminance_offset}) => {
-
-					let background_hsl = rgbToHsl(background_color);
-					background_hsl.l -= luminance_offset;
-
 					return this.assemble_css(
 						"body.theme-dark",
 						tag_name,
 						color,
-						hslToRgb(background_hsl)
+						this.get_background_color(
+							background_color,
+							luminance_offset,
+							false
+						)
 					)
 				});
 	}

--- a/src/style_manager/wranglers/StyleWranglerKanbanCards.ts
+++ b/src/style_manager/wranglers/StyleWranglerKanbanCards.ts
@@ -21,8 +21,6 @@ export class StyleWranglerKanbanCards extends StyleWrangler {
 	// Methods
 	// -----------------------------------------------------------------------------------------------------------------
 	assemble_css_light(): Array<string> {
-		const opacity_border = this.plugin.settings.Kanban.Values.CardBorderOpacity;
-
 		return this.get_tags()
 			.map(
 				({tag_name, color, background_color,luminance_offset}) => {
@@ -40,8 +38,6 @@ export class StyleWranglerKanbanCards extends StyleWrangler {
 	}
 
 	assemble_css_dark(): Array<string> {
-		const opacity_border = this.plugin.settings.Kanban.Values.CardBorderOpacity;
-
 		return this.get_tags()
 			.map(
 				({tag_name, color, background_color,luminance_offset}) => {

--- a/src/style_manager/wranglers/StyleWranglerKanbanCards.ts
+++ b/src/style_manager/wranglers/StyleWranglerKanbanCards.ts
@@ -26,7 +26,7 @@ export class StyleWranglerKanbanCards extends StyleWrangler {
 				({tag_name, color, background_color,luminance_offset}) => {
 
 					let background_hsl = rgbToHsl(background_color);
-					background_hsl.l -= luminance_offset;
+					background_hsl.l += luminance_offset;
 
 					return this.assemble_css(
 						"body.theme-light",

--- a/src/style_manager/wranglers/StyleWranglerKanbanCards.ts
+++ b/src/style_manager/wranglers/StyleWranglerKanbanCards.ts
@@ -6,7 +6,6 @@ import {StyleWrangler}
 import ColoredTagWranglerPlugin
 	from "src/main";
 import {RGB} from "obsidian";
-import {hslToRgb, rgbToHsl} from "../../lib";
 // ---------------------------------------------------------------------------------------------------------------------
 // Code
 // ---------------------------------------------------------------------------------------------------------------------
@@ -57,7 +56,7 @@ export class StyleWranglerKanbanCards extends StyleWrangler {
 	private assemble_css(theme:string, tag_name:string, color:RGB, background_color:RGB){
 		return`
 ${theme} div.kanban-plugin__item.has-tag-${tag_name} div.kanban-plugin__item-title-wrapper { 
-	background: rgb(${background_color.r}, ${background_color.g}, ${background_color.b}) !important;
+	background: ${this.get_background_string(background_color)} !important;
 }
 ${theme} div.kanban-plugin__item.has-tag-${tag_name}{ 
 	border-color: rgb(${color.r}, ${color.g}, ${color.b}) !important;

--- a/src/style_manager/wranglers/StyleWranglerKanbanHashtags.ts
+++ b/src/style_manager/wranglers/StyleWranglerKanbanHashtags.ts
@@ -5,7 +5,6 @@ import {StyleWrangler}
 	from "src/style_manager/wranglers/StyleWrangler";
 import ColoredTagWranglerPlugin
 	from "src/main";
-import {RGB} from "obsidian";
 // ---------------------------------------------------------------------------------------------------------------------
 // Code
 // ---------------------------------------------------------------------------------------------------------------------

--- a/src/style_manager/wranglers/StyleWranglerKanbanLists.ts
+++ b/src/style_manager/wranglers/StyleWranglerKanbanLists.ts
@@ -6,7 +6,6 @@ import {StyleWrangler}
 import ColoredTagWranglerPlugin
 	from "src/main";
 import {RGB} from "obsidian";
-import {hslToRgb, rgbToHsl} from "../../lib";
 // ---------------------------------------------------------------------------------------------------------------------
 // Code
 // ---------------------------------------------------------------------------------------------------------------------
@@ -57,7 +56,7 @@ export class StyleWranglerKanbanLists extends StyleWrangler {
 	private assemble_css(theme:string, tag_name:string, color:RGB, background_color:RGB){
 		return`
 ${theme} div.kanban-plugin__lane:has(div.kanban-plugin__lane-title-text a[href="#${tag_name}"]){
-	background: rgb(${background_color.r}, ${background_color.g}, ${background_color.b}) !important;
+	background: ${this.get_background_string(background_color)} !important;
 	border-color: rgb(${color.r}, ${color.g}, ${color.b}) !important;
 }
 ${theme} div.kanban-plugin__lane-header-wrapper:has(div.kanban-plugin__lane-title-text a[href="#${tag_name}"]){

--- a/src/style_manager/wranglers/StyleWranglerKanbanLists.ts
+++ b/src/style_manager/wranglers/StyleWranglerKanbanLists.ts
@@ -24,15 +24,15 @@ export class StyleWranglerKanbanLists extends StyleWrangler {
 		return this.get_tags()
 			.map(
 				({tag_name, color, background_color,luminance_offset}) => {
-
-					let background_hsl = rgbToHsl(background_color);
-					background_hsl.l += luminance_offset;
-
 					return this.assemble_css(
 						"body.theme-light",
 						tag_name,
 						color,
-						hslToRgb(background_hsl)
+						this.get_background_color(
+							background_color,
+							luminance_offset,
+							true
+						)
 					)
 				});
 	}
@@ -41,15 +41,15 @@ export class StyleWranglerKanbanLists extends StyleWrangler {
 		return this.get_tags()
 			.map(
 				({tag_name, color, background_color,luminance_offset}) => {
-
-					let background_hsl = rgbToHsl(background_color);
-					background_hsl.l -= luminance_offset;
-
 					return this.assemble_css(
 						"body.theme-dark",
 						tag_name,
 						color,
-						hslToRgb(background_hsl)
+						this.get_background_color(
+							background_color,
+							luminance_offset,
+							false
+						)
 					)
 				});
 	}

--- a/src/style_manager/wranglers/StyleWranglerKanbanLists.ts
+++ b/src/style_manager/wranglers/StyleWranglerKanbanLists.ts
@@ -24,13 +24,13 @@ export class StyleWranglerKanbanLists extends StyleWrangler {
 
 		return this.get_tags()
 			.map(
-				({tag_name, color, background_color,background_opacity}) => {
+				({tag_name, color, background_color,luminance_offset}) => {
 					return this.assemble_css(
 						"body.theme-light",
 						tag_name,
 						color,
 						background_color,
-						background_opacity,
+						luminance_offset,
 						opacity_border,
 					)
 				});
@@ -41,22 +41,22 @@ export class StyleWranglerKanbanLists extends StyleWrangler {
 
 		return this.get_tags()
 			.map(
-				({tag_name, color, background_color,background_opacity}) => {
+				({tag_name, color, background_color,luminance_offset}) => {
 					return this.assemble_css(
 						"body.theme-dark",
 						tag_name,
 						color,
 						background_color,
-						background_opacity,
+						luminance_offset,
 						opacity_border,
 					)
 				});
 	}
 
-	private assemble_css(theme:string, tag_name:string, color:RGB, background_color:RGB, background_opacity:number, opacity_border:number){
+	private assemble_css(theme:string, tag_name:string, color:RGB, background_color:RGB, luminance_offset:number, opacity_border:number){
 		return`
 ${theme} div.kanban-plugin__lane:has(div.kanban-plugin__lane-title-text a[href="#${tag_name}"]){
-	background : rgba(${background_color.r}, ${background_color.g}, ${background_color.b}, ${background_opacity}) !important;
+	background : rgb(${background_color.r}, ${background_color.g}, ${background_color.b}}) !important;
 	border-color: rgba(${color.r}, ${color.g}, ${color.b}, ${opacity_border}) !important;
 }
 ${theme} div.kanban-plugin__lane-header-wrapper:has(div.kanban-plugin__lane-title-text a[href="#${tag_name}"]){

--- a/src/style_manager/wranglers/StyleWranglerKanbanLists.ts
+++ b/src/style_manager/wranglers/StyleWranglerKanbanLists.ts
@@ -57,7 +57,7 @@ export class StyleWranglerKanbanLists extends StyleWrangler {
 	private assemble_css(theme:string, tag_name:string, color:RGB, background_color:RGB){
 		return`
 ${theme} div.kanban-plugin__lane:has(div.kanban-plugin__lane-title-text a[href="#${tag_name}"]){
-	background : rgb(${background_color.r}, ${background_color.g}, ${background_color.b}}) !important;
+	background: rgb(${background_color.r}, ${background_color.g}, ${background_color.b}) !important;
 	border-color: rgb(${color.r}, ${color.g}, ${color.b}) !important;
 }
 ${theme} div.kanban-plugin__lane-header-wrapper:has(div.kanban-plugin__lane-title-text a[href="#${tag_name}"]){

--- a/src/style_manager/wranglers/StyleWranglerKanbanLists.ts
+++ b/src/style_manager/wranglers/StyleWranglerKanbanLists.ts
@@ -26,7 +26,7 @@ export class StyleWranglerKanbanLists extends StyleWrangler {
 				({tag_name, color, background_color,luminance_offset}) => {
 
 					let background_hsl = rgbToHsl(background_color);
-					background_hsl.l -= luminance_offset;
+					background_hsl.l += luminance_offset;
 
 					return this.assemble_css(
 						"body.theme-light",

--- a/src/style_manager/wranglers/StyleWranglerKanbanLists.ts
+++ b/src/style_manager/wranglers/StyleWranglerKanbanLists.ts
@@ -6,6 +6,7 @@ import {StyleWrangler}
 import ColoredTagWranglerPlugin
 	from "src/main";
 import {RGB} from "obsidian";
+import {hslToRgb, rgbToHsl} from "../../lib";
 // ---------------------------------------------------------------------------------------------------------------------
 // Code
 // ---------------------------------------------------------------------------------------------------------------------
@@ -20,47 +21,47 @@ export class StyleWranglerKanbanLists extends StyleWrangler {
 	// Methods
 	// -----------------------------------------------------------------------------------------------------------------
 	assemble_css_light(): Array<string> {
-		const opacity_border = this.plugin.settings.Kanban.Values.ListBorderOpacity;
-
 		return this.get_tags()
 			.map(
 				({tag_name, color, background_color,luminance_offset}) => {
+
+					let background_hsl = rgbToHsl(background_color);
+					background_hsl.l -= luminance_offset;
+
 					return this.assemble_css(
 						"body.theme-light",
 						tag_name,
 						color,
-						background_color,
-						luminance_offset,
-						opacity_border,
+						hslToRgb(background_hsl)
 					)
 				});
 	}
 
 	assemble_css_dark(): Array<string> {
-		const opacity_border = this.plugin.settings.Kanban.Values.ListBorderOpacity;
-
 		return this.get_tags()
 			.map(
 				({tag_name, color, background_color,luminance_offset}) => {
+
+					let background_hsl = rgbToHsl(background_color);
+					background_hsl.l -= luminance_offset;
+
 					return this.assemble_css(
 						"body.theme-dark",
 						tag_name,
 						color,
-						background_color,
-						luminance_offset,
-						opacity_border,
+						hslToRgb(background_hsl)
 					)
 				});
 	}
 
-	private assemble_css(theme:string, tag_name:string, color:RGB, background_color:RGB, luminance_offset:number, opacity_border:number){
+	private assemble_css(theme:string, tag_name:string, color:RGB, background_color:RGB){
 		return`
 ${theme} div.kanban-plugin__lane:has(div.kanban-plugin__lane-title-text a[href="#${tag_name}"]){
 	background : rgb(${background_color.r}, ${background_color.g}, ${background_color.b}}) !important;
-	border-color: rgba(${color.r}, ${color.g}, ${color.b}, ${opacity_border}) !important;
+	border-color: rgb(${color.r}, ${color.g}, ${color.b}) !important;
 }
 ${theme} div.kanban-plugin__lane-header-wrapper:has(div.kanban-plugin__lane-title-text a[href="#${tag_name}"]){
-	border-color: rgba(${color.r}, ${color.g}, ${color.b}, ${opacity_border}) !important;
+	border-color: rgb(${color.r}, ${color.g}, ${color.b}) !important;
 }`
 
 	}

--- a/src/style_manager/wranglers/StyleWranglerTags.ts
+++ b/src/style_manager/wranglers/StyleWranglerTags.ts
@@ -7,6 +7,7 @@ import ColoredTagWranglerPlugin
 	from "src/main";
 import {RGB}
 	from "obsidian";
+import {hslToRgb, rgbToHsl} from "../../lib";
 // ---------------------------------------------------------------------------------------------------------------------
 // Code
 // ---------------------------------------------------------------------------------------------------------------------
@@ -21,42 +22,40 @@ export class StyleWranglerTags extends StyleWrangler {
 	// Methods
 	// -----------------------------------------------------------------------------------------------------------------
 	assemble_css_light(): Array<string> {
-		const background_opacity_hover = this.plugin.settings.TagColors.Values.BackgroundOpacityHover;
+		const luminance_offset_hover = this.plugin.settings.TagColors.Values.BackgroundOpacityHover;
 		return this.get_tags()
 			.map(
-				({tag_name, color, background_color, background_opacity}) => this.assemble_css(
+				({tag_name, color, background_color, luminance_offset}) => this.assemble_css(
 					"body.theme-light",
 					tag_name,
 					color,
-					background_color,
-					1-background_opacity,
-					1-background_opacity_hover
+					background_color
 				));
 	}
 
 	assemble_css_dark(): Array<string> {
-		const background_opacity_hover = this.plugin.settings.TagColors.Values.BackgroundOpacityHover;
+		const luminance_offset_hover = this.plugin.settings.TagColors.Values.BackgroundOpacityHover;
 		return this.get_tags()
 			.map(
-				({tag_name, color, background_color, background_opacity}) => this.assemble_css(
+				({tag_name, color, background_color, luminance_offset}) => this.assemble_css(
 					"body.theme-dark",
 					tag_name,
 					color,
-					background_color,
-					background_opacity,
-					background_opacity_hover
+					background_color
 				));
 	}
 
-	private assemble_css(theme:string, tag_name:string, color:RGB, background_color:RGB, background_opacity:number, background_opacity_hover:number){
-		return`
-${theme} .tag[href="#${tag_name}"], .cm-tag-${tag_name} { 
-	--color: rgb(${color.r}, ${color.g}, ${color.b});
-	--color-hover: var(--color);
-	--background: rgba(${background_color.r}, ${background_color.g}, ${background_color.b}, ${background_opacity});
-	--background-hover: rgba(${background_color.r}, ${background_color.g}, ${background_color.b}, ${background_opacity_hover});
-}`
+	private assemble_css(theme:string, tag_name:string, color:RGB, background_color:RGB){
+		let important = this.plugin.settings.FolderNote.Values.ForceImportant ? "!important" : ""
 
+		// noinspection CssInvalidPropertyValue,CssInvalidFunction
+		return` 
+${theme} .tag[href="#${tag_name}"], 
+${theme} .cm-tag-${tag_name} { 
+	color: rgb(${color.r}, ${color.g}, ${color.b}) ${important};
+	background-color: rgb(${background_color.r}, ${background_color.g}, ${background_color.b}) ${important};
+}
+`
 	}
 
 }

--- a/src/style_manager/wranglers/StyleWranglerTags.ts
+++ b/src/style_manager/wranglers/StyleWranglerTags.ts
@@ -7,7 +7,6 @@ import ColoredTagWranglerPlugin
 	from "src/main";
 import {RGB}
 	from "obsidian";
-import {hslToRgb, rgbToHsl} from "../../lib";
 // ---------------------------------------------------------------------------------------------------------------------
 // Code
 // ---------------------------------------------------------------------------------------------------------------------
@@ -22,10 +21,9 @@ export class StyleWranglerTags extends StyleWrangler {
 	// Methods
 	// -----------------------------------------------------------------------------------------------------------------
 	assemble_css_light(): Array<string> {
-		const luminance_offset_hover = this.plugin.settings.TagColors.Values.BackgroundOpacityHover;
 		return this.get_tags()
 			.map(
-				({tag_name, color, background_color, luminance_offset}) => this.assemble_css(
+				({tag_name, color, background_color}) => this.assemble_css(
 					"body.theme-light",
 					tag_name,
 					color,
@@ -34,10 +32,9 @@ export class StyleWranglerTags extends StyleWrangler {
 	}
 
 	assemble_css_dark(): Array<string> {
-		const luminance_offset_hover = this.plugin.settings.TagColors.Values.BackgroundOpacityHover;
 		return this.get_tags()
 			.map(
-				({tag_name, color, background_color, luminance_offset}) => this.assemble_css(
+				({tag_name, color, background_color}) => this.assemble_css(
 					"body.theme-dark",
 					tag_name,
 					color,
@@ -48,12 +45,12 @@ export class StyleWranglerTags extends StyleWrangler {
 	private assemble_css(theme:string, tag_name:string, color:RGB, background_color:RGB){
 		let important = this.plugin.settings.FolderNote.Values.ForceImportant ? "!important" : ""
 
-		// noinspection CssInvalidPropertyValue,CssInvalidFunction
+		// noinspection CssInvalidPropertyValue,CssInvalidFunction,CssUnusedSymbol
 		return` 
 ${theme} .tag[href="#${tag_name}"], 
 ${theme} .cm-tag-${tag_name} { 
 	color: rgb(${color.r}, ${color.g}, ${color.b}) ${important};
-	background-color: rgb(${background_color.r}, ${background_color.g}, ${background_color.b}) ${important};
+	background-color: ${this.get_background_string(background_color)} ${important};
 }
 `
 	}

--- a/src/style_manager/wranglers/StyleWranglerTagsCanvas.ts
+++ b/src/style_manager/wranglers/StyleWranglerTagsCanvas.ts
@@ -3,12 +3,10 @@
 // ---------------------------------------------------------------------------------------------------------------------
 import {StyleWrangler}
 	from "src/style_manager/wranglers/StyleWrangler";
-import {HSL, RGB}
+import {RGB}
 	from "obsidian";
 import ColoredTagWranglerPlugin
 	from "src/main";
-import {hslToRgb, rgbToHsl}
-	from "src/lib/ColorConverters";
 // ---------------------------------------------------------------------------------------------------------------------
 // Code
 // ---------------------------------------------------------------------------------------------------------------------
@@ -23,8 +21,6 @@ export class StyleWranglerTagsCanvas extends StyleWrangler {
 	// Methods
 	// -----------------------------------------------------------------------------------------------------------------
 	assemble_css_light(): Array<string> {
-		const opacity_border = this.plugin.settings.Canvas.Values.CardBorderOpacity;
-
 		return this.get_tags()
 			.map(
 				({tag_name, color, background_color,luminance_offset}) => {
@@ -61,7 +57,7 @@ export class StyleWranglerTagsCanvas extends StyleWrangler {
 	private assemble_css(theme:string, tag_name:string, color:RGB, background_color:RGB){
 		return`
 ${theme} div.canvas-node-container:has(div.markdown-embed-content a[href="#${tag_name}"]) {
-	background : rgb(${background_color.r}, ${background_color.g}, ${background_color.b}) !important;
+	background : ${this.get_background_string(background_color)} !important;
 	border-color: rgb(${color.r}, ${color.g}, ${color.b}) !important;
 }`
 

--- a/src/style_manager/wranglers/StyleWranglerTagsCanvas.ts
+++ b/src/style_manager/wranglers/StyleWranglerTagsCanvas.ts
@@ -24,20 +24,17 @@ export class StyleWranglerTagsCanvas extends StyleWrangler {
 	// -----------------------------------------------------------------------------------------------------------------
 	assemble_css_light(): Array<string> {
 		const opacity_border = this.plugin.settings.Canvas.Values.CardBorderOpacity;
-		const background_luminance_offset = this.plugin.settings.Canvas.Values.CardBackgroundLuminanceOffset;
 
 		return this.get_tags()
 			.map(
-				({tag_name, color, background_color,background_opacity}) => {
-					const hsl:HSL = rgbToHsl(background_color);
-					hsl.l += background_opacity;
-					const color2 = hslToRgb(hsl);
-					const background_rgb:string = `${color2.r}, ${color2.g}, ${color2.b}`;
+				({tag_name, color, background_color,luminance_offset}) => {
+					let hsl_background = rgbToHsl(background_color);
+					hsl_background.l -= luminance_offset
 					return this.assemble_css(
 						"body.theme-light",
 						tag_name,
 						color,
-						background_rgb,
+						hslToRgb(hsl_background),
 						opacity_border,
 					)
 				});
@@ -45,29 +42,26 @@ export class StyleWranglerTagsCanvas extends StyleWrangler {
 
 	assemble_css_dark(): Array<string> {
 		const opacity_border = this.plugin.settings.Canvas.Values.CardBorderOpacity;
-		const background_luminance_offset = this.plugin.settings.Canvas.Values.CardBackgroundLuminanceOffset;
 
 		return this.get_tags()
 			.map(
-				({tag_name, color, background_color, background_opacity}) => {
-					const hsl:HSL = rgbToHsl(background_color);
-					hsl.l -= background_opacity;
-					const color2 = hslToRgb(hsl);
-					const background_rgb:string = `${color2.r}, ${color2.g}, ${color2.b}`;
+				({tag_name, color, background_color, luminance_offset}) => {
+					let hsl_background = rgbToHsl(background_color);
+					hsl_background.l -= luminance_offset
 					return this.assemble_css(
 						"body.theme-dark",
 						tag_name,
 						color,
-						background_rgb,
+						hslToRgb(hsl_background),
 						opacity_border,
 					)
 				});
 	}
 
-	private assemble_css(theme:string, tag_name:string, color:RGB, background_rgb:string, opacity_border:number){
+	private assemble_css(theme:string, tag_name:string, color:RGB, background_color:RGB, opacity_border:number){
 		return`
 ${theme} div.canvas-node-container:has(div.markdown-embed-content a[href="#${tag_name}"]) {
-	background : rgb(${background_rgb}) !important;
+	background : rgb(${background_color.r}, ${background_color.g}, ${background_color.b}) !important;
 	border-color: rgba(${color.r}, ${color.g}, ${color.b}, ${opacity_border}) !important;
 }`
 

--- a/src/style_manager/wranglers/StyleWranglerTagsCanvas.ts
+++ b/src/style_manager/wranglers/StyleWranglerTagsCanvas.ts
@@ -28,13 +28,15 @@ export class StyleWranglerTagsCanvas extends StyleWrangler {
 		return this.get_tags()
 			.map(
 				({tag_name, color, background_color,luminance_offset}) => {
-					let hsl_background = rgbToHsl(background_color);
-					hsl_background.l += luminance_offset
 					return this.assemble_css(
 						"body.theme-light",
 						tag_name,
 						color,
-						hslToRgb(hsl_background)
+						this.get_background_color(
+							background_color,
+							luminance_offset,
+							true
+						)
 					)
 				});
 	}
@@ -43,13 +45,15 @@ export class StyleWranglerTagsCanvas extends StyleWrangler {
 		return this.get_tags()
 			.map(
 				({tag_name, color, background_color, luminance_offset}) => {
-					let hsl_background = rgbToHsl(background_color);
-					hsl_background.l -= luminance_offset
 					return this.assemble_css(
 						"body.theme-dark",
 						tag_name,
 						color,
-						hslToRgb(hsl_background)
+						this.get_background_color(
+							background_color,
+							luminance_offset,
+							false
+						)
 					)
 				});
 	}

--- a/src/style_manager/wranglers/StyleWranglerTagsCanvas.ts
+++ b/src/style_manager/wranglers/StyleWranglerTagsCanvas.ts
@@ -29,7 +29,7 @@ export class StyleWranglerTagsCanvas extends StyleWrangler {
 			.map(
 				({tag_name, color, background_color,luminance_offset}) => {
 					let hsl_background = rgbToHsl(background_color);
-					hsl_background.l -= luminance_offset
+					hsl_background.l += luminance_offset
 					return this.assemble_css(
 						"body.theme-light",
 						tag_name,

--- a/src/style_manager/wranglers/StyleWranglerTagsCanvas.ts
+++ b/src/style_manager/wranglers/StyleWranglerTagsCanvas.ts
@@ -34,15 +34,12 @@ export class StyleWranglerTagsCanvas extends StyleWrangler {
 						"body.theme-light",
 						tag_name,
 						color,
-						hslToRgb(hsl_background),
-						opacity_border,
+						hslToRgb(hsl_background)
 					)
 				});
 	}
 
 	assemble_css_dark(): Array<string> {
-		const opacity_border = this.plugin.settings.Canvas.Values.CardBorderOpacity;
-
 		return this.get_tags()
 			.map(
 				({tag_name, color, background_color, luminance_offset}) => {
@@ -52,17 +49,16 @@ export class StyleWranglerTagsCanvas extends StyleWrangler {
 						"body.theme-dark",
 						tag_name,
 						color,
-						hslToRgb(hsl_background),
-						opacity_border,
+						hslToRgb(hsl_background)
 					)
 				});
 	}
 
-	private assemble_css(theme:string, tag_name:string, color:RGB, background_color:RGB, opacity_border:number){
+	private assemble_css(theme:string, tag_name:string, color:RGB, background_color:RGB){
 		return`
 ${theme} div.canvas-node-container:has(div.markdown-embed-content a[href="#${tag_name}"]) {
 	background : rgb(${background_color.r}, ${background_color.g}, ${background_color.b}) !important;
-	border-color: rgba(${color.r}, ${color.g}, ${color.b}, ${opacity_border}) !important;
+	border-color: rgb(${color.r}, ${color.g}, ${color.b}) !important;
 }`
 
 	}

--- a/styles.css
+++ b/styles.css
@@ -1,25 +1,25 @@
 /* Custom tag colors */
 /* ------------------------------------------------------------------------- */
 /*noinspection ALL*/
-a.tag,
-.cm-hashtag {
-    --color: var(--tag-color);
-    --color-hover: var(--tag-color-hover);
-    --background: var(--tag-background);
-    --background-hover: var(--tag-background-hover);
+/*a.tag,*/
+/*.cm-hashtag {*/
+/*    --color: var(--tag-color);*/
+/*    --color-hover: var(--tag-color-hover);*/
+/*    --background: var(--tag-background);*/
+/*    --background-hover: var(--tag-background-hover);*/
 
-    /*noinspection CssUnresolvedCustomProperty*/
-    background-color: var(--background) !important;
-    color: var(--color) !important;
-    transition: all 0.5s ease;
-    /*padding-top: 2px !important;*/ /* TODO MAKE THIS A SETTING */
-    /*padding-bottom: 2px !important;*/ /* TODO MAKE THIS A SETTING */
-}
-a.tag:hover {
-    /*noinspection CssUnresolvedCustomProperty*/
-    background-color: var(--background-hover) !important;
-    color: var(--color-hover) !important;
-}
+/*    !*noinspection CssUnresolvedCustomProperty*!*/
+/*    background-color: var(--background) !important;*/
+/*    color: var(--color) !important;*/
+/*    transition: all 0.5s ease;*/
+/*    !*padding-top: 2px !important;*! !* TODO MAKE THIS A SETTING *!*/
+/*    !*padding-bottom: 2px !important;*! !* TODO MAKE THIS A SETTING *!*/
+/*}*/
+/*a.tag:hover {*/
+/*    !*noinspection CssUnresolvedCustomProperty*!*/
+/*    background-color: var(--background-hover) !important;*/
+/*    color: var(--color-hover) !important;*/
+/*}*/
 
 .colored_tags_wrangler-settings-kanban,
 .colored_tags_wrangler-settings-tags{

--- a/styles.css
+++ b/styles.css
@@ -27,6 +27,12 @@
 	font-size: larger;
 }
 
+/* Text area for Multi Tags */
 .cwt-settings-tab textarea{
     width: 100%;
+}
+
+/* Luminance offset things */
+.cwt-settings-tab input[type=text]:nth-child(5){
+	width: 15%;
 }

--- a/styles.css
+++ b/styles.css
@@ -33,6 +33,9 @@
 }
 
 /* Luminance offset things */
+.cwt-settings-tab div:nth-child(25) > div.setting-item-control > input[type=text]{
+	width: 30%;
+}
 .cwt-settings-tab input[type=text]:nth-child(5){
 	width: 15%;
 }


### PR DESCRIPTION
In the fix that I made, I've removed the opacity system all together, and replaced it with an (HSL) Luminance offset system for extra integrations like Kanban Lists and Cards, Canvas items and Folder Notes. This should fix the issue of the colors of the tag not matching the color of the given field.

Like the toggle to enable separated backgrounds, there is now a toggle to view the luminance offset for a given tag. This value ranges from -0.5 to 0.5 and is applied differently in darkmode vs lightmode.

In Darkmode this turns the backgrounds darker,
Example: luminance offset value of `0.5` will result in a darker color 
Example: luminance offset value of `-0.5` will result in a brighter color 

In Lightmode it turns them brighter.
Example: luminance offset value of `0.5` will result in a brighter color 
Example: luminance offset value of `-0.5` will result in a darker color 

This modifier only applies to kanban cards/lists, Canvas card and Folder Note system

---
### Light Mode: 
![image](https://github.com/code-of-chaos/obsidian-colored_tags_wrangler/assets/74367457/3091a494-6584-42fe-a3ec-9670601434ad)
![image](https://github.com/code-of-chaos/obsidian-colored_tags_wrangler/assets/74367457/b6d703dd-10ea-4b90-8c54-6013938eb24f)
![image](https://github.com/code-of-chaos/obsidian-colored_tags_wrangler/assets/74367457/15c60e38-4acb-4d98-ba0c-dd0ff41addd4)
![image](https://github.com/code-of-chaos/obsidian-colored_tags_wrangler/assets/74367457/30e3186f-db2e-48c1-9836-87fb7031286a)

---
### Dark Mode: 
![image](https://github.com/code-of-chaos/obsidian-colored_tags_wrangler/assets/74367457/10081d5e-2c93-4ded-9bcc-ee5e09c82679)
![image](https://github.com/code-of-chaos/obsidian-colored_tags_wrangler/assets/74367457/11b21ee7-2cab-401d-a85b-7665fbe3e00a)
![image](https://github.com/code-of-chaos/obsidian-colored_tags_wrangler/assets/74367457/0274340d-ba83-4619-8663-1793179a11f3)
![image](https://github.com/code-of-chaos/obsidian-colored_tags_wrangler/assets/74367457/0fb54d78-4b6e-4f7e-a197-a7a2508f11e7)

(The red is very over powering in the default example haha)

---
New settings have been added to tweak this by the user

![image](https://github.com/code-of-chaos/obsidian-colored_tags_wrangler/assets/74367457/9fa1628b-02f7-4e34-87ba-8e6f12f69b0a)